### PR TITLE
Add private _compAddress to Unitroller/comptroller

### DIFF
--- a/contracts/BondRedeemer.sol
+++ b/contracts/BondRedeemer.sol
@@ -13,7 +13,7 @@ import "./openzeppelin/SafeERC20.sol";
 contract BondRedeemer is Ownable {
     //Incorrect boilerplate addresses
     using SafeERC20 for IERC20;
-    address public constant BDAMM = 0xc4F125F56e10980A26093c5ad22AEa1FA93cfd57; 
+    address public constant BDAMM = 0xc4F125F56e10980A26093c5ad22AEa1FA93cfd57;
     address public constant DAMM = 0xD9aA9fD99c2C085ce82A7f084A451C2460FCd73e;
     address public constant CHAINLINK_DAMM = 0x2c1d072e956AFFC0D435Cb7AC38EF18d24d9127c; //using $LINK Oracle for testing
     address public admin;

--- a/contracts/CToken.sol
+++ b/contracts/CToken.sol
@@ -705,7 +705,7 @@ abstract contract CToken is CTokenInterface, ExponentialNoError, TokenErrorRepor
             // accrueInterest emits logs on errors, but we still want to log the fact that an attempted liquidation failed
             revert LiquidateAccrueCollateralInterestFailed(error);
         }
-        
+
         // liquidateBorrowFresh emits borrow-specific logs on errors, so we don't need to
         liquidateBorrowFresh(msg.sender, borrower, repayAmount, cTokenCollateral);
     }

--- a/contracts/ComptrollerG7.sol
+++ b/contracts/ComptrollerG7.sol
@@ -61,7 +61,7 @@ contract ComptrollerG7 is ComptrollerV5Storage, ComptrollerInterface, Comptrolle
 
     /// @notice Emitted when borrow cap guardian is changed
     event NewBorrowCapGuardian(address oldBorrowCapGuardian, address newBorrowCapGuardian);
-    
+
     /// @notice Emitted when new borrower is whitelisted
     event BorrowerWhitelisted(address borrower);
 
@@ -518,7 +518,7 @@ contract ComptrollerG7 is ComptrollerV5Storage, ComptrollerInterface, Comptrolle
         uint repayAmount) override external returns (uint) {
         // Shh - currently unused
         liquidator;
-        
+
         if (!markets[cTokenBorrowed].isListed || !markets[cTokenCollateral].isListed) {
             return uint(Error.MARKET_NOT_LISTED);
         }

--- a/contracts/ComptrollerG7.sol
+++ b/contracts/ComptrollerG7.sol
@@ -83,7 +83,10 @@ contract ComptrollerG7 is ComptrollerV5Storage, ComptrollerInterface, Comptrolle
     // No collateralFactorMantissa may exceed this value
     uint internal constant collateralFactorMaxMantissa = 0.9e18; // 0.9
 
-    constructor() public {
+    address private _compAddress;
+
+    constructor(address compAddress) public {
+        _compAddress = compAddress;
         admin = msg.sender;
     }
 
@@ -1369,6 +1372,6 @@ contract ComptrollerG7 is ComptrollerV5Storage, ComptrollerInterface, Comptrolle
      * @return The address of COMP
      */
     function getCompAddress() public view returns (address) {
-        return 0xc00e94Cb662C3520282E6f5717214004A7f26888;
+        return _compAddress;
     }
 }

--- a/contracts/ComptrollerInterface.sol
+++ b/contracts/ComptrollerInterface.sol
@@ -18,7 +18,6 @@ abstract contract ComptrollerInterface {
     function redeemAllowed(address cToken, address redeemer, uint redeemTokens) virtual external returns (uint);
     function redeemVerify(address cToken, address redeemer, uint redeemAmount, uint redeemTokens) virtual external;
 
-    //Josh
     function whitelistBorrowerAdd(address borrower) virtual external returns (uint);
     function setBorrowerLimits(address borrower, uint256 _borrowLimit) virtual external returns (uint);
     function getBorrowerLimits(address borrower) virtual external returns (uint);

--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -52,7 +52,7 @@ contract ComptrollerV1Storage is UnitrollerAdminStorage {
      * @notice Per-account mapping of "assets you are in", capped by maxAssets
      */
     mapping(address => CToken[]) public accountAssets;
-    
+
     mapping(address => bool) public borrowerArray;
 
     mapping(address => uint256) public borrowLimit;

--- a/contracts/Unitroller.sol
+++ b/contracts/Unitroller.sol
@@ -30,7 +30,14 @@ contract Unitroller is UnitrollerAdminStorage, ComptrollerErrorReporter {
       */
     event NewAdmin(address oldAdmin, address newAdmin);
 
-    constructor() public {
+    /**
+      * @notice Emitted _compAddress is initially set (when accepting the first comptroller implementation)
+      */
+    event NewCompAddress(address oldAddress, address newAddress);
+
+    address private _compAddress;
+
+    constructor() {
         // Set admin to caller
         admin = msg.sender;
     }
@@ -65,6 +72,13 @@ contract Unitroller is UnitrollerAdminStorage, ComptrollerErrorReporter {
         // Save current values for inclusion in log
         address oldImplementation = comptrollerImplementation;
         address oldPendingImplementation = pendingComptrollerImplementation;
+
+        if (_compAddress == address(0)) {
+            (bool success, bytes memory compAddress) = pendingComptrollerImplementation.call(abi.encodeWithSignature("getCompAddress()"));
+            require(success, "failed at getCompAddress()");
+            _compAddress = abi.decode(compAddress, (address));
+            emit NewCompAddress(address(0), _compAddress);
+        }
 
         comptrollerImplementation = pendingComptrollerImplementation;
 


### PR DESCRIPTION
This enables us to have the Comptroller take the Comp address as a
parameter instead of being hardcoded.

Since Comptroller is used via proxy, Unitroller declares _compAddress
also, and copies the value from Comptroller._compAddress when its
own _compAddress value is unset, and the Comptroller implementation
is added.